### PR TITLE
[Visualizer] Remove plotly_visualizer from imports and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ ar_hackathon/
 │   │   └── routing_utils.py       # Routing utility functions
 │   ├── visualizers/               # Visualization components
 │   │   ├── base_visualizer.py     # Base visualizer class
-│   │   ├── bokeh_visualizer.py    # Bokeh visualization implementation
 │   │   ├── network_visualizer.py  # Network visualization implementation
-│   │   ├── plotly_visualizer.py   # Plotly visualization implementation
 │   │   └── visualizer_factory.py  # Factory for creating visualizers
 │   ├── examples/                  # Example implementations
 │   │   └── basic_router.py        # Basic routing implementation
@@ -77,6 +75,16 @@ python scripts/run_game.py test_cases/level1/test_case_1.json --router basic
 ```
 
 ### Visualizing the Game
+
+#### Pre-Requisite
+
+Kaleido requires Google Chrome to be installed. If Chrome is not installed, a static visualization can still be viewed by accessing frames in `visualization_output/` directly.
+
+#### Running the Visualizer
+
+Visualization output will be saved to the `visualization_output/` directory.
+
+Example:
 
 ```bash
 # Visualize the game with the default router

--- a/ar_hackathon/visualizers/__init__.py
+++ b/ar_hackathon/visualizers/__init__.py
@@ -5,7 +5,6 @@ This package contains visualizer implementations for the Amazon Robotics Hackath
 """
 
 from ar_hackathon.visualizers.base_visualizer import BaseVisualizer
-from ar_hackathon.visualizers.plotly_visualizer import PlotlyVisualizer
 from ar_hackathon.visualizers.visualizer_factory import VisualizerFactory
 
-__all__ = ['BaseVisualizer', 'PlotlyVisualizer', 'VisualizerFactory']
+__all__ = ['BaseVisualizer', 'VisualizerFactory']


### PR DESCRIPTION
Excess visualizers were removed with commit [e1286e6](https://github.com/jamzaon/ArHackathon2025/commit/e1286e6)

This fixes the following import error by removing these imports from __init__.py:

```
python scripts/visualize.py test_cases/level1/test_case_1.json

Traceback (most recent call last):
  File "/Volumes/workplace/ArHackathon2025/scripts/visualize.py", line 11, in <module>
    from ar_hackathon.simulation_runner import SimulationRunner
  File "/Volumes/workplace/ArHackathon2025/ar_hackathon/simulation_runner.py", line 13, in <module>
    from ar_hackathon.visualizers.base_visualizer import BaseVisualizer
  File "/Volumes/workplace/ArHackathon2025/ar_hackathon/visualizers/__init__.py", line 8, in <module>
    from ar_hackathon.visualizers.plotly_visualizer import PlotlyVisualizer
ModuleNotFoundError: No module named 'ar_hackathon.visualizers.plotly_visualizer'
```